### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/shortcut_lib/src/main/java/com/xys/badge_lib/AppInfoUtil.java
+++ b/shortcut_lib/src/main/java/com/xys/badge_lib/AppInfoUtil.java
@@ -5,7 +5,11 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 
-public class AppInfoUtil {
+public final class AppInfoUtil {
+
+    private AppInfoUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * Retrieve launcher activity name of the application from the context

--- a/shortcut_lib/src/main/java/com/xys/badge_lib/BadgeUtil.java
+++ b/shortcut_lib/src/main/java/com/xys/badge_lib/BadgeUtil.java
@@ -16,7 +16,11 @@ import com.xys.shortcut_lib.R;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-public class BadgeUtil {
+public final class BadgeUtil {
+
+    private BadgeUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * 设置Badge 目前支持Launcher:

--- a/shortcut_lib/src/main/java/com/xys/shortcut_lib/FlowEntranceUtil.java
+++ b/shortcut_lib/src/main/java/com/xys/shortcut_lib/FlowEntranceUtil.java
@@ -8,7 +8,11 @@ import android.content.pm.PackageManager;
  * Created by xuyisheng on 15/10/30.
  * Version 1.0
  */
-public class FlowEntranceUtil {
+public final class FlowEntranceUtil {
+
+    private FlowEntranceUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * 显示\隐藏Launcher入口

--- a/shortcut_lib/src/main/java/com/xys/shortcut_lib/LauncherUtil.java
+++ b/shortcut_lib/src/main/java/com/xys/shortcut_lib/LauncherUtil.java
@@ -16,9 +16,13 @@ import java.util.List;
  *
  * @version 1.0
  */
-public class LauncherUtil {
+public final class LauncherUtil {
 
     private static String mBufferedValue = null;
+
+    private LauncherUtil() throws InstantiationException {
+      throw new InstantiationException("This class is not for instantiation");  
+    }
 
     /**
      * get the current Launcher's Package Name

--- a/shortcut_lib/src/main/java/com/xys/shortcut_lib/ShortcutSuperUtils.java
+++ b/shortcut_lib/src/main/java/com/xys/shortcut_lib/ShortcutSuperUtils.java
@@ -21,7 +21,11 @@ import java.util.List;
  * Created by xuyisheng on 15/11/6.
  * version 1.0
  */
-public class ShortcutSuperUtils {
+public final class ShortcutSuperUtils {
+
+    private ShortcutSuperUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * 判断快捷方式是否存在

--- a/shortcut_lib/src/main/java/com/xys/shortcut_lib/ShortcutUtils.java
+++ b/shortcut_lib/src/main/java/com/xys/shortcut_lib/ShortcutUtils.java
@@ -8,12 +8,16 @@ import android.graphics.Bitmap;
  * Created by xuyisheng on 15/10/30.
  * Version 1.0
  */
-public class ShortcutUtils {
+public final class ShortcutUtils {
 
     // Action 添加Shortcut
     public static final String ACTION_ADD_SHORTCUT = "com.android.launcher.action.INSTALL_SHORTCUT";
     // Action 移除Shortcut
     public static final String ACTION_REMOVE_SHORTCUT = "com.android.launcher.action.UNINSTALL_SHORTCUT";
+
+    private ShortcutUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     /**
      * 添加快捷方式


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
