### PR TITLE
修改AndroidManifest.xml 文件中LAUNCHER 的配置，解决桌面出现2个应用图标的问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,9 +20,7 @@
             android:name="com.xys.shortcut_lib.ShortcutActivity"
             android:theme="@style/Base.Theme.AppCompat.Dialog">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
AndroidManifest.xml 文件中ShortcutActivity 入口配置改为
action android:name="android.intent.action.CREATE_SHORTCUT" 
解决桌面出现2个应用图标的问题     
